### PR TITLE
Fix OOM while allocating buffers in the direct memory

### DIFF
--- a/chassis/configuration/configuration/coordination.http.server/coordinator.http.server.conf.xml
+++ b/chassis/configuration/configuration/coordination.http.server/coordinator.http.server.conf.xml
@@ -29,10 +29,10 @@
             <list>
                 <bean id="connector" class="org.eclipse.jetty.server.nio.SelectChannelConnector">
                     <property name="port" value="${chassis.coordination.http.port}"/>
-                    <property name="requestBufferSize" value="2097152"/>
-                    <property name="requestHeaderSize" value="2097152"/>
-                    <property name="responseBufferSize" value="2097152"/>
-                    <property name="responseHeaderSize" value="2097152"/>
+                    <property name="requestBufferSize" value="262144"/>
+                    <property name="requestHeaderSize" value="524288"/>
+                    <property name="responseBufferSize" value="262144"/>
+                    <property name="responseHeaderSize" value="262144"/>
                 </bean>
             </list>
         </property>


### PR DESCRIPTION
Restored old dimensions except request header
