### PR TITLE
Apache Http Invoker: 'Path' could be passed in query

### DIFF
--- a/chassis/invokers/src/main/java/com/griddynamics/jagger/invoker/http/ApacheHttpInvoker.java
+++ b/chassis/invokers/src/main/java/com/griddynamics/jagger/invoker/http/ApacheHttpInvoker.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 
-public class ApacheHttpInvoker extends  ApacheAbstractHttpInvoker<HttpRequestBase> {
+public class ApacheHttpInvoker extends ApacheAbstractHttpInvoker<HttpRequestBase> {
     private static final Logger log = LoggerFactory.getLogger(ApacheHttpInvoker.class);
 
     @Override
@@ -41,6 +41,9 @@ public class ApacheHttpInvoker extends  ApacheAbstractHttpInvoker<HttpRequestBas
                 uriBuilder.setQuery(query.getURI().getQuery());
                 uriBuilder.setFragment(query.getURI().getFragment());
                 uriBuilder.setUserInfo(query.getURI().getUserInfo());
+                if (!query.getURI().getPath().isEmpty()) {
+                    uriBuilder.setPath(query.getURI().getPath());
+                }
                 query.setURI(uriBuilder.build());
                 return query;
             }


### PR DESCRIPTION
Provide ability to set path with query. (not only with endpoint)
If "path" occurs in query it will be used in final http-request.
Else - "path" from 'endpoint'.
