### PR TITLE
Added timeout for setting up JMX connection

### DIFF
--- a/monitoring/agent/src/main/java/com/griddynamics/jagger/agent/impl/JMXSystemUnderTestImpl.java
+++ b/monitoring/agent/src/main/java/com/griddynamics/jagger/agent/impl/JMXSystemUnderTestImpl.java
@@ -58,6 +58,7 @@ public class JMXSystemUnderTestImpl implements SystemUnderTestService {
     private String name;
     private String urlFormat;
     private Timeout jmxConnectionTimeout = new Timeout(300, "JmxConnectionTimeout");
+    private Timeout jmxConnectionRetryDelay = new Timeout(3000, "JmxConnectionRetryDelay");
     private Map<String, MBeanServerConnection> connections = Maps.newHashMap();
 
     public void setJmxServices(String jmxServices) {
@@ -78,6 +79,10 @@ public class JMXSystemUnderTestImpl implements SystemUnderTestService {
 
     public void setJmxConnectionTimeout(Timeout jmxConnectionTimeout) {
         this.jmxConnectionTimeout = jmxConnectionTimeout;
+    }
+
+    public void setJmxConnectionRetryDelay(Timeout jmxConnectionRetryDelay) {
+        this.jmxConnectionRetryDelay = jmxConnectionRetryDelay;
     }
 
     @Override
@@ -122,7 +127,7 @@ public class JMXSystemUnderTestImpl implements SystemUnderTestService {
                 break;
             } catch (IOException e) {
                 log.error("Error during JMX initializing", e);
-                TimeUtils.sleepMillis(3000);
+                TimeUtils.sleepMillis(jmxConnectionRetryDelay.getValue());
             }
         }
         if (connections.size() == 0) {

--- a/monitoring/agent/src/main/resources/spring/agent.config.xml
+++ b/monitoring/agent/src/main/resources/spring/agent.config.xml
@@ -86,6 +86,7 @@
         <property name="jmxServices" value="${jmx.services}"/>
         <property name="name" value="#{agentConfig.getName()}"/>
         <property name="jmxConnectionTimeout" ref="jmxConnectionTimeout"/>
+        <property name="jmxConnectionRetryDelay" ref="jmxConnectionRetryDelay"/>
     </bean>
 
     <!--bean id="jvmSnmpCollector" class="com.griddynamics.jagger.agent.impl.SNMPProvider">
@@ -138,6 +139,11 @@
     <bean id="jmxConnectionTimeout" class="com.griddynamics.jagger.util.Timeout">
         <property name="value" value="${jmx.connection.timeout}"/>
         <property name="name"  value="jmx.connection.timeout"/>
+    </bean>
+
+    <bean id="jmxConnectionRetryDelay" class="com.griddynamics.jagger.util.Timeout">
+        <property name="value" value="${jmx.connection.retry.delay}"/>
+        <property name="name"  value="jmx.connection.retry.delay"/>
     </bean>
 
     <bean id="defaultExchanger" class="com.griddynamics.jagger.coordinator.http.DefaultPackExchanger">

--- a/monitoring/agent/src/main/resources/spring/agent.properties
+++ b/monitoring/agent/src/main/resources/spring/agent.properties
@@ -21,7 +21,10 @@
 jmx.enabled=true
 jmx.services=localhost:9875
 jmx.monitoring.timeout=300
+# Timeout for attempt to connect to JMX port
 jmx.connection.timeout=300
+# Delay between connection retries
+jmx.connection.retry.delay=3000
 jmx.profiler.timeout=300
 jmx.url.format=service:jmx:rmi:///jndi/rmi://%s/jmxrmi
 


### PR DESCRIPTION
Seems now agent is not retrying to connect to JMX host:port. It stops right after getting exception.

jmxConnectionTimeout provides an ability to retry to get JMX connection during it
