### PR TITLE
JFG-677 Could not package jagger with gwt-maven-plugin version:2.4.0 in chassis.util

### DIFF
--- a/chassis/util/pom.xml
+++ b/chassis/util/pom.xml
@@ -148,7 +148,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>gwt-maven-plugin</artifactId>
-                <version>2.4.0</version>
+                <version>2.5.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/webclient/pom.xml
+++ b/webclient/pom.xml
@@ -245,7 +245,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>gwt-maven-plugin</artifactId>
-                <version>2.4.0</version>
+                <version>2.5.1</version>
                 <dependencies>
                     <dependency>
                         <groupId>com.google.gwt</groupId>


### PR DESCRIPTION
- transition to the new version of gwt-maven-plugin. Because of problem with maven2 building failures.
