### PR TITLE
CalculateIntervalSizeProvider can provide intervalsCount + 1 points(intervals)

### DIFF
--- a/chassis/core/src/main/java/com/griddynamics/jagger/reporting/interval/CalculatedIntervalSizeProvider.java
+++ b/chassis/core/src/main/java/com/griddynamics/jagger/reporting/interval/CalculatedIntervalSizeProvider.java
@@ -15,6 +15,6 @@ public class CalculatedIntervalSizeProvider implements IntervalSizeProvider {
 
     @Override
     public int getIntervalSize(long minTime, long maxTime) {
-        return (int) ((maxTime - minTime) / intervalsCount);
+        return (int) Math.ceil((1d * maxTime - minTime) / intervalsCount);
     }
 }


### PR DESCRIPTION
synthetic example.
intervalsCount = 7; 
minTime = 1;
maxTime = 123;
was => interval size = 17
17 \* 7 = 119 . that means that there will be one more interval to cover last point(s).
is => interval size = 18
18*7 =126. - all point covered.
