### PR TITLE
Formatting of yAxis label fix

### DIFF
--- a/webclient/src/main/java/com/griddynamics/jagger/webclient/client/trends/Trends.java
+++ b/webclient/src/main/java/com/griddynamics/jagger/webclient/client/trends/Trends.java
@@ -654,6 +654,7 @@ public class Trends extends DefaultActivity {
                     }
 
                     private NumberFormat calculateNumberFormat(double tickValue) {
+                        tickValue = Math.abs(tickValue);
 
                         if (tickValue > 999999) {
                             return NumberFormat.getFormat("#.###E0#");


### PR DESCRIPTION
If values of metric was negative only scientific notation format was used.
- calculate format with absolute value
