### PR TITLE
Fail to start webclient

### DIFF
--- a/webclient/src/main/resources/spring/persistence.conf.xml
+++ b/webclient/src/main/resources/spring/persistence.conf.xml
@@ -56,5 +56,8 @@
     <bean id="entityManagerFactory" class="org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean">
         <property name="dataSource" ref="dataSource"/>
         <property name="persistenceUnitName" value="jagger"/>
+        <property name="jpaDialect">
+            <bean class="org.springframework.orm.jpa.vendor.HibernateJpaDialect" />
+        </property>
     </bean>
 </beans>


### PR DESCRIPTION
> > tomcat log
> > SEVERE: Exception sending context initialized event to listener instance of class org.springframework.web.context.ContextLoaderListener
> > org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'entityManagerFactory' defined in class path resource [spring/persistence.conf.xml]: Invocation of init method failed; nested exception is javax.persistence.PersistenceException: [PersistenceUnit: jagger] Unable to build EntityManagerFactory
> >     at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1455)
> >     at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:519)
> >     at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:456)
> >     at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:294)
> >     at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:225)
> >     at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:291)
> >     at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:193)
> >     at org.springframework.context.support.AbstractApplicationContext.getBean(AbstractApplicationContext.java:1105)
> >     at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:915)
> >     at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:472)
> >     at org.springframework.web.context.ContextLoader.configureAndRefreshWebApplicationContext(ContextLoader.java:388)
> >     at org.springframework.web.context.ContextLoader.initWebApplicationContext(ContextLoader.java:293)
> >     at org.springframework.web.context.ContextLoaderListener.contextInitialized(ContextLoaderListener.java:111)
> >     at org.apache.catalina.core.StandardContext.listenerStart(StandardContext.java:4994)
> >     at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5492)
> >     at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:150)
> >     at org.apache.catalina.core.ContainerBase.addChildInternal(ContainerBase.java:901)
> >     at org.apache.catalina.core.ContainerBase.addChild(ContainerBase.java:877)
> >     at org.apache.catalina.core.StandardHost.addChild(StandardHost.java:649)
> >     at org.apache.catalina.startup.HostConfig.deployWAR(HostConfig.java:1081)
> >     at org.apache.catalina.startup.HostConfig$DeployWar.run(HostConfig.java:1877)
> >     at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
> >     at java.util.concurrent.FutureTask.run(FutureTask.java:262)
> >     at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
> >     at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
> >     at java.lang.Thread.run(Thread.java:745)
> > Caused by: javax.persistence.PersistenceException: [PersistenceUnit: jagger] Unable to build EntityManagerFactory
> >     at org.hibernate.ejb.Ejb3Configuration.buildEntityManagerFactory(Ejb3Configuration.java:900)
> >     at org.hibernate.ejb.HibernatePersistence.createContainerEntityManagerFactory(HibernatePersistence.java:74)
> >     at org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean.createNativeEntityManagerFactory(LocalContainerEntityManagerFactoryBean.java:287)
> >     at org.springframework.orm.jpa.AbstractEntityManagerFactoryBean.afterPropertiesSet(AbstractEntityManagerFactoryBean.java:310)
> >     at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1514)
> >     at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1452)
> >     ... 25 more
> > Caused by: org.hibernate.HibernateException: 'hibernate.dialect' must be set when no Connection available
> >     at org.hibernate.dialect.resolver.DialectFactory.buildDialect(DialectFactory.java:107)
> >     at org.hibernate.cfg.SettingsFactory.buildSettings(SettingsFactory.java:138)
> >     at org.hibernate.cfg.Configuration.buildSettingsInternal(Configuration.java:2163)
> >     at org.hibernate.cfg.Configuration.buildSettings(Configuration.java:2159)
> >     at org.hibernate.cfg.Configuration.buildSessionFactory(Configuration.java:1383)
> >     at org.hibernate.cfg.AnnotationConfiguration.buildSessionFactory(AnnotationConfiguration.java:954)
> >     at org.hibernate.ejb.Ejb3Configuration.buildEntityManagerFactory(Ejb3Configuration.java:891)
> >     ... 30 more
> > <<
> > - dialectJpa property to entityManagerFactory
