### PR TITLE
JFG-839 Report is not generated when jagger is started on default H2 database

### DIFF
--- a/chassis/configuration/configuration/common/storage.rdb.client.conf.xml
+++ b/chassis/configuration/configuration/common/storage.rdb.client.conf.xml
@@ -34,11 +34,12 @@
 		<property name="dataSource" ref="dataSource"/>
 	</bean>
 
-	<bean id="dataSource" class="org.apache.commons.dbcp.BasicDataSource">
+	<bean id="dataSource" class="com.griddynamics.jagger.storage.rdb.RewritebleBatchedStatementsBasicDataSource">
 		<property name="driverClassName" value="${chassis.storage.rdb.client.driver}" />
-		<property name="url" value="${chassis.storage.rdb.client.url}?rewriteBatchedStatements=true" />
+		<property name="url" value="${chassis.storage.rdb.client.url}" />
 		<property name="username" value="${chassis.storage.rdb.username}" />
 		<property name="password" value="${chassis.storage.rdb.password}" />
+    <property name="rewriteBatchedStatements" value="true"/>
         <property name="testOnBorrow" value="true"/>
         <property name="validationQuery" value="SELECT 1;"/>
         <property name="minIdle" value="5"/>

--- a/chassis/core/src/main/java/com/griddynamics/jagger/storage/rdb/RewritebleBatchedStatementsBasicDataSource.java
+++ b/chassis/core/src/main/java/com/griddynamics/jagger/storage/rdb/RewritebleBatchedStatementsBasicDataSource.java
@@ -1,0 +1,35 @@
+package com.griddynamics.jagger.storage.rdb;
+
+import org.apache.commons.dbcp.BasicDataSource;
+
+import java.sql.SQLException;
+
+/**
+ * @author Artem Zhdanov <azhdanov@griddynamics.com>
+ * @since 08/01/2015
+ */
+public class RewritebleBatchedStatementsBasicDataSource extends BasicDataSource implements RewritebleBatchedStatementsDataSource {
+
+    public static final String REWRITE_BATCHED_STATEMENTS = "rewriteBatchedStatements";
+
+    @Override
+    public boolean getRewriteBatchedStatements() {
+        final String isRewrite = super.connectionProperties.getProperty(REWRITE_BATCHED_STATEMENTS);
+        return isRewrite == null ? null : Boolean.valueOf(isRewrite);
+    }
+
+    @Override
+    public void setRewriteBatchedStatements(final boolean rewriteBatchedStatements) {
+        super.addConnectionProperty("includeSynonyms", String.valueOf(rewriteBatchedStatements));
+    }
+
+    @Override
+    public <T> T unwrap(final Class<T> iface) throws SQLException {
+        throw new UnsupportedOperationException("Is not implemented by org.apache.commons.dbcp.BasicDataSource so we will not implement it either");
+    }
+
+    @Override
+    public boolean isWrapperFor(final Class<?> iface) throws SQLException {
+        throw new UnsupportedOperationException("Is not implemented by org.apache.commons.dbcp.BasicDataSource so we will not implement it either");
+    }
+}

--- a/chassis/core/src/main/java/com/griddynamics/jagger/storage/rdb/RewritebleBatchedStatementsBasicDataSource.java
+++ b/chassis/core/src/main/java/com/griddynamics/jagger/storage/rdb/RewritebleBatchedStatementsBasicDataSource.java
@@ -20,7 +20,7 @@ public class RewritebleBatchedStatementsBasicDataSource extends BasicDataSource 
 
     @Override
     public void setRewriteBatchedStatements(final boolean rewriteBatchedStatements) {
-        super.addConnectionProperty("includeSynonyms", String.valueOf(rewriteBatchedStatements));
+        super.addConnectionProperty(REWRITE_BATCHED_STATEMENTS, String.valueOf(rewriteBatchedStatements));
     }
 
     @Override

--- a/chassis/core/src/main/java/com/griddynamics/jagger/storage/rdb/RewritebleBatchedStatementsBasicDataSource.java
+++ b/chassis/core/src/main/java/com/griddynamics/jagger/storage/rdb/RewritebleBatchedStatementsBasicDataSource.java
@@ -10,12 +10,12 @@ import java.sql.SQLException;
  */
 public class RewritebleBatchedStatementsBasicDataSource extends BasicDataSource implements RewritebleBatchedStatementsDataSource {
 
-    public static final String REWRITE_BATCHED_STATEMENTS = "rewriteBatchedStatements";
+    private static final String REWRITE_BATCHED_STATEMENTS = "rewriteBatchedStatements";
 
     @Override
     public boolean getRewriteBatchedStatements() {
         final String isRewrite = super.connectionProperties.getProperty(REWRITE_BATCHED_STATEMENTS);
-        return isRewrite == null ? null : Boolean.valueOf(isRewrite);
+        return isRewrite == null ? false : Boolean.valueOf(isRewrite);
     }
 
     @Override

--- a/chassis/core/src/main/java/com/griddynamics/jagger/storage/rdb/RewritebleBatchedStatementsDataSource.java
+++ b/chassis/core/src/main/java/com/griddynamics/jagger/storage/rdb/RewritebleBatchedStatementsDataSource.java
@@ -1,0 +1,14 @@
+package com.griddynamics.jagger.storage.rdb;
+
+import javax.sql.DataSource;
+
+/**
+ * @author Artem Zhdanov <azhdanov@griddynamics.com>
+ * @since 08/01/2015
+ */
+public interface RewritebleBatchedStatementsDataSource extends DataSource {
+
+    public boolean getRewriteBatchedStatements();
+
+    public void setRewriteBatchedStatements(boolean rewriteBatchedStatements);
+}


### PR DESCRIPTION
Internal storage is H2 by default. But the execution fails because H2 jdbc driver does not support '?' symbol in JDBC url string. https://issues.griddynamics.net/browse/JFG-839