### PR TITLE
Add feature : Combine summary on webui for metrics with synonyms

### DIFF
--- a/dbapi/pom.xml
+++ b/dbapi/pom.xml
@@ -48,6 +48,12 @@
             <groupId>com.griddynamics.jagger</groupId>
             <artifactId>chassis.util</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/dbapi/src/main/java/com/griddynamics/jagger/dbapi/DatabaseService.java
+++ b/dbapi/src/main/java/com/griddynamics/jagger/dbapi/DatabaseService.java
@@ -36,8 +36,11 @@ public interface DatabaseService {
 
     /** Returns map <metricNode, plot values> for specific metric nodes from control tree
      * @param metricNodes - set of metric nodes
+     * @param isCombineSynonymsInSummaryEnabled combine summary of metrics with synonyms to single (first) MetricNameDto
      * @return plot values for metric nodes */
-     Map<MetricNode, SummaryIntegratedDto> getSummaryByMetricNodes(Set<MetricNode> metricNodes, boolean isEnableDecisionsPerMetricFetching);
+     Map<MetricNode, SummaryIntegratedDto> getSummaryByMetricNodes(Set<MetricNode> metricNodes,
+                                                                 boolean isEnableDecisionsPerMetricFetching,
+                                                                 boolean isCombineSynonymsInSummaryEnabled);
 
     /** Returns summary values for current metrics
      * @param metricNames - metric names

--- a/dbapi/src/main/java/com/griddynamics/jagger/dbapi/model/WebClientProperties.java
+++ b/dbapi/src/main/java/com/griddynamics/jagger/dbapi/model/WebClientProperties.java
@@ -2,6 +2,9 @@ package com.griddynamics.jagger.dbapi.model;
 
 import java.io.Serializable;
 
+/**
+ * Web Ui properties holder.
+ */
 public class WebClientProperties implements Serializable {
 
     private boolean tagsAvailable = false;
@@ -11,6 +14,7 @@ public class WebClientProperties implements Serializable {
     private boolean showOnlyMatchedTests = true;
     private int userCommentMaxLength = 1000;
     private boolean enableDecisionsPerMetricHighlighting = true;
+    private boolean combineSynonymsInSummary = true;
 
     public boolean isTagsAvailable() {
         return tagsAvailable;
@@ -66,5 +70,16 @@ public class WebClientProperties implements Serializable {
 
     public void setEnableDecisionsPerMetricHighlighting(boolean enableDecisionsPerMetricHighlighting) {
         this.enableDecisionsPerMetricHighlighting = enableDecisionsPerMetricHighlighting;
+    }
+
+    /**
+     * Combine summary/trend values within one MetricNode for synonyms.
+     */
+    public boolean isCombineSynonymsInSummary() {
+        return combineSynonymsInSummary;
+    }
+
+    public void setCombineSynonymsInSummary(boolean combineSynonymsInSummary) {
+        this.combineSynonymsInSummary = combineSynonymsInSummary;
     }
 }

--- a/dbapi/src/main/java/com/griddynamics/jagger/dbapi/util/MetricNameUtil.java
+++ b/dbapi/src/main/java/com/griddynamics/jagger/dbapi/util/MetricNameUtil.java
@@ -1,9 +1,18 @@
 package com.griddynamics.jagger.dbapi.util;
 
+import com.google.common.collect.Lists;
 import com.griddynamics.jagger.dbapi.dto.MetricNameDto;
+import com.griddynamics.jagger.dbapi.dto.SummaryMetricValueDto;
+import com.griddynamics.jagger.dbapi.dto.SummarySingleDto;
 import com.griddynamics.jagger.dbapi.model.MetricNode;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class MetricNameUtil {
 
@@ -61,5 +70,63 @@ public class MetricNameUtil {
         }
 
         return metricNameDtoSet;
+    }
+
+    /**
+     * Combines SummarySingleDto into single SummarySingleDto using synonyms.
+     *
+     * @throws java.lang.NullPointerException if ${code rowList} is null.
+     */
+    public static List<SummarySingleDto> combineSynonyms(List<SummarySingleDto> rowList) {
+
+        List<SummarySingleDto> resultList = new ArrayList<SummarySingleDto>();
+        Map<String, List<SummarySingleDto>> groupMap = new HashMap<String, List<SummarySingleDto>>();
+        for (SummarySingleDto summarySingleDto: rowList) {
+            if (summarySingleDto.getMetricName().getMetricNameSynonyms() == null) {
+                // no synonyms, just add to result list
+                resultList.add(summarySingleDto);
+            } else {
+                List<String> synonyms = summarySingleDto.getMetricName().getMetricNameSynonyms();
+                boolean grouped = false;
+                for (String synonym: synonyms) {
+                    if (groupMap.containsKey(synonym)) {
+                        // update entry with new summarySingleDto
+                        groupMap.get(synonym).add(summarySingleDto);
+                        grouped = true;
+                        break;
+                    }
+                }
+                if (!grouped) {
+                    // new entry to the map
+                    groupMap.put(summarySingleDto.getMetricName().getMetricName(), Lists.newArrayList(summarySingleDto));
+                }
+            }
+        }
+
+
+        if (!groupMap.isEmpty()) {
+            // add combined summary:
+            for (List<SummarySingleDto> groupedSummaries: groupMap.values()) {
+                if (groupedSummaries.size() == 1) {
+                    resultList.add(groupedSummaries.get(0));
+                    continue;
+                }
+                // generate new combined summary
+                SummarySingleDto combinedSummary = new SummarySingleDto();
+
+                // use first MetricNameDto
+                combinedSummary.setMetricName(groupedSummaries.get(0).getMetricName());
+
+                Set<SummaryMetricValueDto> combinedValues = new HashSet<SummaryMetricValueDto>();
+                for (SummarySingleDto ssd: groupedSummaries) {
+                    combinedValues.addAll(ssd.getValues());
+                }
+                combinedSummary.setValues(combinedValues);
+
+                resultList.add(combinedSummary);
+            }
+        }
+
+        return resultList;
     }
 }

--- a/dbapi/src/test/java/com/griddynamics/jagger/dbapi/util/MetricNameUtilTest.java
+++ b/dbapi/src/test/java/com/griddynamics/jagger/dbapi/util/MetricNameUtilTest.java
@@ -1,0 +1,103 @@
+package com.griddynamics.jagger.dbapi.util;
+
+import com.griddynamics.jagger.dbapi.dto.MetricNameDto;
+import com.griddynamics.jagger.dbapi.dto.SummaryMetricValueDto;
+import com.griddynamics.jagger.dbapi.dto.SummarySingleDto;
+import org.testng.annotations.Test;
+
+import java.util.*;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class MetricNameUtilTest {
+
+    @Test
+    public void combineSynonymsEmptyTest() throws Exception {
+
+        List<SummarySingleDto> input = Collections.emptyList();
+        assertTrue(MetricNameUtil.combineSynonyms(input).isEmpty());
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void combineSynonymsNullTest() throws Exception {
+
+        MetricNameUtil.combineSynonyms(null);
+    }
+
+    @Test
+    public void combineSynonymsSimpleTest() throws Exception {
+
+        SummarySingleDto ssd1 = new SummarySingleDto();
+        MetricNameDto mnd1 = new MetricNameDto(null, "m1");
+        mnd1.setMetricNameSynonyms(Arrays.asList("m2", "m3"));
+        ssd1.setMetricName(mnd1);
+        Set<SummaryMetricValueDto> values1 = new HashSet<SummaryMetricValueDto>();
+        values1.add(createSummaryMetricValueDto(24, "val1"));
+        values1.add(createSummaryMetricValueDto(35, "val2"));
+        ssd1.setValues(values1);
+
+        SummarySingleDto ssd2 = new SummarySingleDto();
+        MetricNameDto mnd2 = new MetricNameDto(null, "m2");
+        mnd2.setMetricNameSynonyms(Arrays.asList("m1", "m3"));
+        ssd2.setMetricName(mnd2);
+        Set<SummaryMetricValueDto> values2 = new HashSet<SummaryMetricValueDto>();
+        values2.add(createSummaryMetricValueDto(26, "val3"));
+        values2.add(createSummaryMetricValueDto(37, "val4"));
+        ssd2.setValues(values2);
+
+        List<SummarySingleDto> input = Arrays.asList(ssd1, ssd2);
+        List<SummarySingleDto> output = MetricNameUtil.combineSynonyms(input);
+
+        assertEquals(output.size(), 1, "input should be combined into single output");
+
+        assertEquals(output.get(0).getMetricName(), mnd1, "output should contains first metric name dto");
+
+        Set<SummaryMetricValueDto> outputValues = output.get(0).getValues();
+        assertEquals(outputValues.size(), 4, "should be 4 summary values");
+
+        Set<SummaryMetricValueDto> allSummaryMetricValues = new HashSet<SummaryMetricValueDto>();
+        allSummaryMetricValues.addAll(values1);
+        allSummaryMetricValues.addAll(values2);
+        for (SummaryMetricValueDto sv: allSummaryMetricValues) {
+            assertTrue(outputValues.contains(sv), "output values should contain all values from input");
+        }
+    }
+
+    @Test
+    public void combineSynonymsNoNeedTest() throws Exception {
+
+        SummarySingleDto ssd1 = new SummarySingleDto();
+        MetricNameDto mnd1 = new MetricNameDto(null, "m1");
+        mnd1.setMetricNameSynonyms(Arrays.asList("m4", "m7"));
+        ssd1.setMetricName(mnd1);
+        Set<SummaryMetricValueDto> values1 = new HashSet<SummaryMetricValueDto>();
+        values1.add(createSummaryMetricValueDto(24, "val1"));
+        values1.add(createSummaryMetricValueDto(35, "val2"));
+        ssd1.setValues(values1);
+
+        SummarySingleDto ssd2 = new SummarySingleDto();
+        MetricNameDto mnd2 = new MetricNameDto(null, "m2");
+        ssd2.setMetricName(mnd2);
+        Set<SummaryMetricValueDto> values2 = new HashSet<SummaryMetricValueDto>();
+        values2.add(createSummaryMetricValueDto(26, "val3"));
+        values2.add(createSummaryMetricValueDto(37, "val4"));
+        ssd2.setValues(values2);
+
+        List<SummarySingleDto> input = Arrays.asList(ssd1, ssd2);
+        List<SummarySingleDto> output = MetricNameUtil.combineSynonyms(input);
+
+        assertEquals(output.size(), 2, "input should not be combined");
+
+        assertTrue(output.contains(ssd1), "input should not be combined");
+        assertTrue(output.contains(ssd2), "input should not be combined");
+    }
+
+
+    private static SummaryMetricValueDto createSummaryMetricValueDto(long sessionId, String value) {
+        SummaryMetricValueDto smvd1 = new SummaryMetricValueDto();
+        smvd1.setSessionId(sessionId);
+        smvd1.setValue(value);
+        return smvd1;
+    }
+}

--- a/webclient/src/main/java/com/griddynamics/jagger/webclient/client/MetricDataService.java
+++ b/webclient/src/main/java/com/griddynamics/jagger/webclient/client/MetricDataService.java
@@ -31,5 +31,7 @@ public interface MetricDataService extends RemoteService {
         }
     }
 
-    public Map<MetricNode, SummaryIntegratedDto> getMetrics(Set<MetricNode> metricNames, boolean isEnableDecisionsPerMetricFetching) throws RuntimeException;
+    public Map<MetricNode, SummaryIntegratedDto> getMetrics(Set<MetricNode> metricNames,
+                                                boolean isEnableDecisionsPerMetricFetching,
+                                                boolean isCombineSynonymsInSummaryEnabled) throws  RuntimeException;
 }

--- a/webclient/src/main/java/com/griddynamics/jagger/webclient/client/MetricDataServiceAsync.java
+++ b/webclient/src/main/java/com/griddynamics/jagger/webclient/client/MetricDataServiceAsync.java
@@ -4,8 +4,6 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.griddynamics.jagger.dbapi.dto.SummaryIntegratedDto;
 import com.griddynamics.jagger.dbapi.model.MetricNode;
 
-
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -19,5 +17,6 @@ import java.util.Set;
 public interface MetricDataServiceAsync {
 
     void getMetrics(Set<MetricNode> metricNames, boolean isEnableDecisionsPerMetricHighlighting,
+                    boolean isCombineSynonymsInSummaryEnabled,
                     AsyncCallback<Map<MetricNode, SummaryIntegratedDto>> async);
 }

--- a/webclient/src/main/java/com/griddynamics/jagger/webclient/client/trends/Trends.java
+++ b/webclient/src/main/java/com/griddynamics/jagger/webclient/client/trends/Trends.java
@@ -1605,24 +1605,26 @@ public class Trends extends DefaultActivity {
 
                 if (!notLoaded.isEmpty()) {
                     disableControl();
-                    MetricDataService.Async.getInstance().getMetrics(notLoaded, webClientProperties.isEnableDecisionsPerMetricHighlighting(),
-                        new AsyncCallback<Map<MetricNode, SummaryIntegratedDto>>() {
-                        @Override
-                        public void onFailure(Throwable caught) {
-                            caught.printStackTrace();
-                            new ExceptionPanel(place, caught.getMessage());
-                            if (enableTree)
-                                enableControl();
-                        }
+                    MetricDataService.Async.getInstance().getMetrics(notLoaded,
+                            webClientProperties.isEnableDecisionsPerMetricHighlighting(),
+                            webClientProperties.isCombineSynonymsInSummary(),
+                            new AsyncCallback<Map<MetricNode, SummaryIntegratedDto>>() {
+                                @Override
+                                public void onFailure(Throwable caught) {
+                                    caught.printStackTrace();
+                                    new ExceptionPanel(place, caught.getMessage());
+                                    if (enableTree)
+                                        enableControl();
+                                }
 
-                        @Override
-                        public void onSuccess(Map<MetricNode, SummaryIntegratedDto> result) {
-                            loaded.putAll(result);
-                            renderMetrics(loaded);
-                            if (enableTree)
-                                enableControl();
-                        }
-                    });
+                                @Override
+                                public void onSuccess(Map<MetricNode, SummaryIntegratedDto> result) {
+                                    loaded.putAll(result);
+                                    renderMetrics(loaded);
+                                    if (enableTree)
+                                        enableControl();
+                                }
+                            });
                 } else {
                     renderMetrics(loaded);
                 }

--- a/webclient/src/main/java/com/griddynamics/jagger/webclient/server/MetricDataServiceImpl.java
+++ b/webclient/src/main/java/com/griddynamics/jagger/webclient/server/MetricDataServiceImpl.java
@@ -6,7 +6,8 @@ import com.griddynamics.jagger.dbapi.model.MetricNode;
 import com.griddynamics.jagger.webclient.client.MetricDataService;
 import org.springframework.beans.factory.annotation.Required;
 
-import java.util.*;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Created with IntelliJ IDEA.
@@ -25,7 +26,11 @@ public class MetricDataServiceImpl implements MetricDataService {
     }
 
     @Override
-    public Map<MetricNode, SummaryIntegratedDto> getMetrics(Set<MetricNode> metricNodes, boolean isEnableDecisionsPerMetricFetching) throws RuntimeException {
-        return databaseService.getSummaryByMetricNodes(metricNodes, isEnableDecisionsPerMetricFetching);
+    public Map<MetricNode, SummaryIntegratedDto> getMetrics(Set<MetricNode> metricNodes,
+            boolean isEnableDecisionsPerMetricFetching,
+            boolean isCombineSynonymsInSummaryEnabled) throws  RuntimeException {
+
+        return databaseService.getSummaryByMetricNodes(metricNodes,
+                isEnableDecisionsPerMetricFetching, isCombineSynonymsInSummaryEnabled);
     }
 }

--- a/webclient/src/main/resources/webclient.properties
+++ b/webclient/src/main/resources/webclient.properties
@@ -41,4 +41,7 @@ webui.tags.available=true
 # when true decisions per metric will be fetched from DB and shown in UI
 webui.enable.decisions.per.metric.highlighting=true
 
+# combine metrics within one node
+webui.combine.synonyms.in.summary=true
+
 # end: following section is used for docu generation - Jagger Web Ui properties

--- a/webclient/src/main/webapp/WEB-INF/gwt-servlet.xml
+++ b/webclient/src/main/webapp/WEB-INF/gwt-servlet.xml
@@ -115,6 +115,7 @@
         <property name="tagsAvailable" value="${webui.tags.available:true}"/>
         <property name="showOnlyMatchedTests" value="${webui.show.matched.tests.only:true}"/>
         <property name="enableDecisionsPerMetricHighlighting" value="${webui.enable.decisions.per.metric.highlighting:true}"/>
+        <property name="combineSynonymsInSummary" value="${webui.combine.synonyms.in.summary:true}"/>
     </bean>
 
     <!--==========Control tree creation rules==========-->


### PR DESCRIPTION
- introduced killswitch 'webui.combine.synonyms.in.summary=true'

Combine summary metrics values into single one for metrics in one MetricNode (Node in control tree) and which metricNames  are synonyms to each-other.

Killswitch set to 'true' by default and can be configured via webclient.properties
