### PR TITLE
BufferedLogWriter : log exception

### DIFF
--- a/chassis/core/src/main/java/com/griddynamics/jagger/storage/fs/logging/BufferedLogWriter.java
+++ b/chassis/core/src/main/java/com/griddynamics/jagger/storage/fs/logging/BufferedLogWriter.java
@@ -176,8 +176,7 @@ public abstract class BufferedLogWriter implements LogWriter {
                             objectOutput.writeObject(serializable);
                         }
                     }catch (Exception e){
-                        log.error("Error during saving data with path {} to fileStorage", logFilePath, e);
-
+                        log.error("Error during saving data with path "+ logFilePath + " to fileStorage", e);
                     } finally {
                         try {
                             Closeables.closeQuietly(objectOutput);


### PR DESCRIPTION
This is needed to be committed in order to log exception while writing to fileStorage was failed.

 Currently Exception is not logged, as There is no method Logger.error(String, Object, Throwable) so Logger.error(String, Object, Object) is used instead.

Logger.error(String, Throwable) is the method that is used in current commit.