### PR TITLE
Fixed JavaDoc generation failure on JDK8.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -528,6 +528,7 @@
                     <docfilessubdirs>true</docfilessubdirs>
                     <stylesheetfile>jagger-javadoc.css</stylesheetfile>
                     <detectOfflineLinks>false</detectOfflineLinks>
+                    <additionalparam>-Xdoclint:none</additionalparam>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
	Java8 is more stricker regarding custom tags in JavaDoc
	which causes entire build failure.