### PR TITLE
pom.xml: doclint-java8-disable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,19 @@
 
         <spring.version>3.1.4.RELEASE</spring.version>
     </properties>
-
+  
+    <profiles>
+        <profile>
+           <id>doclint-java8-disable</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <javadoc.opts>-Xdoclint:none</javadoc.opts>
+            </properties>
+        </profile>
+    </profiles>
+  
     <modules>
         <module>dbapi</module>
         <module>monitoring/agent</module>
@@ -528,7 +540,7 @@
                     <docfilessubdirs>true</docfilessubdirs>
                     <stylesheetfile>jagger-javadoc.css</stylesheetfile>
                     <detectOfflineLinks>false</detectOfflineLinks>
-                    <additionalparam>-Xdoclint:none</additionalparam>
+                    <additionalparam>${javadoc.opts}</additionalparam>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Since the parameter "-Xdoclint:none" only exists in Java 8, defining this parameter breaks the build for any other Java. To prevent this, we can create a profile that will be active only for Java 8.