### PR TITLE
[JFG-863] change docker-compose file and jaas/run.sh script

### DIFF
--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     # Expose ports. Either specify both ports (HOST:CONTAINER), or just the
     # container port (a random host port will be chosen).
     ports:
-      - 3306:3306
+      - 3307:3306
     # Set mysql environments
     environment:
       MYSQL_ROOT_PASSWORD: password
@@ -19,11 +19,11 @@ services:
       - ./files/my.cnf:/etc/mysql/conf.d/my.cnf
 
   # Container with mysql base for jaas
-  jagger-jaas-mysql:
+  jaas-mysql:
     image: mysql:5.7
-    container_name: jagger-jaas-mysql
+    container_name: jaas-mysql
     ports:
-      - 3307:3306
+      - 3308:3306
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_USER: jaggeruser
@@ -34,7 +34,7 @@ services:
     image: griddynamics/jagger-web-client:snapshot
     container_name: jagger-web-client
     ports:
-      - 80:80
+      - 8087:80
     # Wait when jagger-mysql container started 
     depends_on:
       - jagger-mysql
@@ -50,16 +50,17 @@ services:
     image: griddynamics/jagger-jaas:snapshot
     container_name: jagger-jaas
     ports:
-      - 8080:8080
+      - 8088:8080
     depends_on:
-      - jagger-jaas-mysql
+      - jaas-mysql
     environment:
       JAAS_HTTP_PORT: 8080
+      JAAS_DB_URL: jdbc:mysql://jaas-mysql:3306/jaasdb
       JAAS_DB_DRIVER: com.mysql.jdbc.Driver
-      JAAS_DB_URL: jdbc:mysql://jagger-jaas-mysql:3306/jaasdb
       JAAS_DB_USER: jaggeruser
       JAAS_DB_PASS: password
       JAAS_HIBERNATE_DIALECT: org.hibernate.dialect.MySQLDialect
+      # These parameters are optional, but you can avoid some issues if they are set (watch JFG-947).
       JAGGER_DB_DEFAULT_URL: jdbc:mysql://jagger-mysql:3306/jaggerdb
       JAGGER_DB_DEFAULT_DESC: default_db
       JAGGER_DB_DEFAULT_USER: jaggeruser

--- a/docker/jagger/jaas/Dockerfile
+++ b/docker/jagger/jaas/Dockerfile
@@ -1,0 +1,12 @@
+FROM openjdk:8u92-jdk-alpine
+
+ENV JAAS_VERSION 1.2.6-SNAPSHOT
+
+ADD ["http://nexus.vm.griddynamics.net:8081/nexus/service/local/artifact/maven/content?r=jagger-snapshots&g=com.griddynamics.jagger&a=jaas&e=jar&v=${JAAS_VERSION}", "/com/griddynamics/jagger/jaas.jar"]
+
+ADD run.sh /com/griddynamics/jagger/run.sh
+RUN chmod +x /com/griddynamics/jagger/run.sh
+
+WORKDIR /com/griddynamics/jagger
+
+CMD /com/griddynamics/jagger/run.sh

--- a/docker/jagger/jaas/run.sh
+++ b/docker/jagger/jaas/run.sh
@@ -1,0 +1,12 @@
+# Check if all important parameters exist:
+
+: "${JAAS_DB_DRIVER:?Need to set JAAS_DB_DRIVER non-empty}"   
+: "${JAAS_HTTP_PORT:?Need to set JAAS_HTTP_PORT non-empty}"   
+: "${JAAS_DB_URL:?Need to set JAAS_DB_URL non-empty}"   
+: "${JAAS_DB_USER:?Need to set JAAS_DB_USER non-empty}"   
+: "${JAAS_DB_PASS:?Need to set JAAS_DB_PASS non-empty}"   
+: "${JAAS_HIBERNATE_DIALECT:?Need to set JAAS_HIBERNATE_DIALECT non-empty}"   
+
+# Command "sleep 10" needed for initialisation of database. Watch JFG-947
+sleep 10
+java -Djaas.hibernate.dialect=${JAAS_HIBERNATE_DIALECT} -Djaas.db.driver=${JAAS_DB_DRIVER} -Djaas.db.url=${JAAS_DB_URL} -Djaas.db.user=${JAAS_DB_USER} -Djaas.db.pass=${JAAS_DB_PASS} -Djagger.db.default.url=${JAGGER_DB_DEFAULT_URL} -Djagger.db.default.desc=${JAGGER_DB_DEFAULT_DESC} -Djagger.db.default.user=${JAGGER_DB_DEFAULT_USER} -Djagger.db.default.pass=${JAGGER_DB_DEFAULT_PASSWORD} -Djagger.db.default.jdbcDriver=${JAGGER_DB_DEFAULT_DRIVER} -Djagger.db.default.hibernateDialect=${JAGGER_DB_DEFAULT_HIBERNATE_DIALECT} -jar /com/griddynamics/jagger/jaas.jar  --server.port=${JAAS_HTTP_PORT}


### PR DESCRIPTION
change default ports and name from jagger-jaas-mysql to jaas-mysql in the docker-compose file. Add more specific error messages in the jaas/run.sh
