### PR TITLE
Issue 859. Add encode to URI builder

### DIFF
--- a/chassis/core/src/main/java/com/griddynamics/jagger/invoker/v2/JHttpEndpoint.java
+++ b/chassis/core/src/main/java/com/griddynamics/jagger/invoker/v2/JHttpEndpoint.java
@@ -187,7 +187,7 @@ public class JHttpEndpoint implements Serializable {
         MultiValueMap<String, String> localQueryParams = new LinkedMultiValueMap<>();
         queryParams.entrySet().forEach(entry -> localQueryParams.add(entry.getKey(), entry.getValue()));
 
-        return fromUri(oldUri).queryParams(localQueryParams).build().toUri();
+        return fromUri(oldUri).queryParams(localQueryParams).build().encode().toUri();
     }
 
     public static JHttpEndpoint copyOf(JHttpEndpoint jHttpEndpoint) {


### PR DESCRIPTION
Fix of not encoded requests for default http invoker.
At the moment special characters are not escaped.
For example "a & b" converted to "a%20&%20b", but not to "a%20%26%20b".